### PR TITLE
Style update with new Google fonts link

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -9,7 +9,7 @@ import {
 import '/src/styles/global.css';
 
 const Button = ({
-  children, url, target, txtColor, bgColor, fontSize, borderStyle, padding, margin, customStyle
+  children, url, target, txtColor, bgColor, fontSize, borderStyle, padding, margin, letterSpacing, customStyle
 }) => {
   const defaultStyle = {
     color: txtColor || "var(--color-primary)",
@@ -18,6 +18,7 @@ const Button = ({
     fontSize: fontSize || "1.0rem",
     padding: padding || "0.18rem 0.4rem",
     margin: margin || "0 0.5rem",
+    letterSpacing: letterSpacing || "-0.01rem",
   };
 
   const styles = { ...defaultStyle, ...customStyle };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Arvo:wght@400;700&family=Lato:wght@300;400;700&family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Arvo:wght@400&family=Lato:wght@300;400;700&family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
 /* 
 Possible fonts to use:
   Arvo
@@ -54,12 +54,14 @@ Good BG Colors:
   --heading-color: var(--color-text-dark);
   --heading-font-family: var(--font-serif);
   --heading-small-font-family: var(--font-sans-serif);
-  --heading-font-weight: 700;
+  --heading-font-weight: 400;
 
   --button-font-family: var(--font-serif);
   --button-font-weight: 400;
   --button-hover-color: #ffffff;
   --button-hover-bg-color: var(--color-primary);
+
+  --logo-font-weight: 700;
 
   --navbar-init-height: 6rem;
 
@@ -94,6 +96,7 @@ h2,
 h3 {
   font-family: var(--heading-font-family);
   font-weight: var(--heading-font-weight);
+  letter-spacing: -0.03rem;
 }
 
 h4,
@@ -106,7 +109,6 @@ h6 {
 h1 {
   font-size: 2.3rem;
   margin: 2rem 0 1.5rem 0;
-  aliasing: antialiased;
 }
 
 h2 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Arvo:wght@700&Lato:300,400,700&Nunito+Sans:ital,wght@0,400;0,700;1,400;1,700);
-
+@import url('https://fonts.googleapis.com/css2?family=Arvo:wght@400;700&family=Lato:wght@300;400;700&family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
 /* 
 Possible fonts to use:
   Arvo
@@ -57,8 +56,8 @@ Good BG Colors:
   --heading-small-font-family: var(--font-sans-serif);
   --heading-font-weight: 700;
 
-  --button-font-family: "Arvo", sans-serif;
-  --button-font-weight: 700;
+  --button-font-family: var(--font-serif);
+  --button-font-weight: 400;
   --button-hover-color: #ffffff;
   --button-hover-bg-color: var(--color-primary);
 
@@ -107,6 +106,7 @@ h6 {
 h1 {
   font-size: 2.3rem;
   margin: 2rem 0 1.5rem 0;
+  aliasing: antialiased;
 }
 
 h2 {


### PR DESCRIPTION
As we discussed in #46, this PR is to test the result of replacing the Google font link with a newer version. I changed the font weight of the button to 400 and left the headings at 700 to show the difference. @MOQN I am not sure how we want it to look, but now it is the same result on both Safari, Chrome & Firefox!